### PR TITLE
remove std::time in favor of get_time

### DIFF
--- a/src/lcg.rs
+++ b/src/lcg.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 // A simple Linear Congruential Generator (LCG)
 pub struct Lcg {
     state: u64,
@@ -8,10 +6,8 @@ pub struct Lcg {
 impl Lcg {
     // Creates a new LCG seeded with the current system time.
     pub fn new() -> Self {
-        let seed = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_nanos() as u64;
+        macroquad::rand::srand(Self::get_new_seed());
+        let seed = macroquad::rand::rand() as u64;
         Self { state: seed }
     }
 
@@ -43,5 +39,13 @@ impl Lcg {
             }
         }
         min + (rand_val % range)
+    }
+
+    fn get_new_seed() -> u64 {
+        let mut string_time = macroquad::time::get_time().to_string();
+        let dot_position = macroquad::time::get_time().to_string().find('.').unwrap();
+        string_time.remove(dot_position);
+
+        string_time.parse::<u64>().unwrap()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use macroquad::prelude::*;
+use macroquad::{color, prelude::*};
 pub mod app;
 pub mod food;
 pub mod lcg;
@@ -14,6 +14,14 @@ pub const SNAKE_UPDATE_INTERVAL: f64 = 0.05;
 
 #[macroquad::main("snakers")]
 async fn main() {
+    loop {
+        draw_text("PRESS ENTER TO START", 200.0, 250.0, 32.0, color::WHITE);
+        next_frame().await;
+        if is_key_down(KeyCode::Enter) {
+            break;
+        }
+    }
+
     let mut app = App::new();
     let mut last_update_time = get_time();
     loop {


### PR DESCRIPTION
Removed std::time to make the project run in the browser as a WASM build.

Added a "PRESS ENTER TO START" screen at the start, not the cleanest way possible, but gets the job done.